### PR TITLE
[app] Pass services space allocator to image handler

### DIFF
--- a/src/app/aoscore.cpp
+++ b/src/app/aoscore.cpp
@@ -101,7 +101,7 @@ void AosCore::Init(const std::string& configFile)
 
     // Initialize image handler
 
-    err = mImageHandler.Init(mCryptoProvider, mLayersSpaceAllocator, mDownloadSpaceAllocator, mOCISpec);
+    err = mImageHandler.Init(mCryptoProvider, mLayersSpaceAllocator, mServicesSpaceAllocator, mOCISpec);
     AOS_ERROR_CHECK_AND_THROW("can't initialize image handler", err);
 
     // Initialize service manager


### PR DESCRIPTION
This patch fixes a typo in the image handler: download space allocator was used instead of services space allocator.