### PR TITLE
launcher: runtime: handle relative device symlink

### DIFF
--- a/src/launcher/runtime.cpp
+++ b/src/launcher/runtime.cpp
@@ -157,7 +157,12 @@ oci::LinuxDevice DeviceFromPath(const fs::path& path)
     auto devPath = path;
 
     if (fs::is_symlink(path)) {
-        devPath = fs::read_symlink(path);
+        auto target = fs::read_symlink(path);
+        if (target.is_relative()) {
+            devPath = (path.parent_path() / target).lexically_normal();
+        } else {
+            devPath = target;
+        }
     }
 
     struct stat sb;

--- a/tests/launcher/CMakeLists.txt
+++ b/tests/launcher/CMakeLists.txt
@@ -24,4 +24,4 @@ gtest_discover_tests(${TARGET})
 # Libraries
 # ######################################################################################################################
 
-target_link_libraries(${TARGET} launcher GTest::gmock_main)
+target_link_libraries(${TARGET} launcher aostestutils GTest::gmock_main)


### PR DESCRIPTION
This patch fixes operation not permitted error when the device path is a relative symlink. The fix resolves the symlink to an absolute path before calling stat().