### PR TITLE
resourcemanager: check if device exists dynamically

### DIFF
--- a/src/resourcemanager/resourcemanager.cpp
+++ b/src/resourcemanager/resourcemanager.cpp
@@ -25,10 +25,6 @@ namespace aos::sm::resourcemanager {
 Error HostDeviceManager::Init()
 {
     try {
-        for (const auto& entry : std::filesystem::directory_iterator(cDevicesDirectory)) {
-            mDevices.insert(entry.path().string());
-        }
-
         if (auto err = ParseGroups(); !err.IsNone()) {
             return AOS_ERROR_WRAP(err);
         }
@@ -51,8 +47,10 @@ Error HostDeviceManager::CheckDevice(const String& device) const
         return AOS_ERROR_WRAP(ErrorEnum::eFailed);
     }
 
-    if (mDevices.find(devices[0].CStr()) == mDevices.end()) {
-        return AOS_ERROR_WRAP(ErrorEnum::eNotFound);
+    std::error_code ec;
+
+    if (!std::filesystem::exists(devices[0].CStr(), ec) || ec.value() != 0) {
+        return AOS_ERROR_WRAP(Error(ErrorEnum::eNotFound, ec.message().c_str()));
     }
 
     return ErrorEnum::eNone;

--- a/src/resourcemanager/resourcemanager.hpp
+++ b/src/resourcemanager/resourcemanager.hpp
@@ -44,12 +44,10 @@ public:
     Error CheckGroup(const String& group) const override;
 
 private:
-    static constexpr auto cDevicesDirectory = "/dev/";
-    static constexpr auto cGroupsFile       = "/etc/group";
+    static constexpr auto cGroupsFile = "/etc/group";
 
     Error ParseGroups();
 
-    std::set<std::string> mDevices;
     std::set<std::string> mGroups;
 };
 

--- a/tests/resourcemanager/resourcemanager_test.cpp
+++ b/tests/resourcemanager/resourcemanager_test.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <filesystem>
+
 #include <gtest/gtest.h>
 
 #include <aos/test/log.hpp>
@@ -17,7 +19,14 @@ namespace aos::sm::resourcemanager {
 
 class ResourcemanagerTest : public Test {
 public:
-    void SetUp() override { test::InitLog(); }
+    void SetUp() override
+    {
+        test::InitLog();
+
+        std::filesystem::create_directories("test/dev/dri/card0");
+    }
+
+    void TearDown() override { std::filesystem::remove_all("test"); }
 
     HostDeviceManager mHostDeviceManager;
 };
@@ -34,6 +43,9 @@ TEST_F(ResourcemanagerTest, CheckDevice)
     EXPECT_TRUE(err.IsNone()) << test::ErrorToStr(err);
 
     err = mHostDeviceManager.CheckDevice("/dev/null:/dev/test");
+    EXPECT_TRUE(err.IsNone()) << test::ErrorToStr(err);
+
+    err = mHostDeviceManager.CheckDevice("test/dev/dri/card0:/dev/dri/card0");
     EXPECT_TRUE(err.IsNone()) << test::ErrorToStr(err);
 }
 


### PR DESCRIPTION
This patch uses std::filesystem to check if the device exists instead of checking if it is in the list of devices. This allows to check for devices that are plugged in after the ResourceManager is initialized. As well as to check devices multiple subfolders deep, e.g. /dev/dri/card0.